### PR TITLE
Allow users to override reqwest features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/filipton/planetscale-driver"
 planetscale-driver-macros = { path = "./macros", version = "0.2.2" }
 anyhow = "1.0.71"
 base64 = "0.21.0"
-reqwest = "0.11.17"
+reqwest = {version = "0.11.17", default-features = false, features= ["rustls-tls"]}
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 async-mutex = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,15 @@ repository = "https://github.com/filipton/planetscale-driver"
 planetscale-driver-macros = { path = "./macros", version = "0.2.2" }
 anyhow = "1.0.71"
 base64 = "0.21.0"
-reqwest = {version = "0.11.17", default-features = false, features= ["rustls-tls"]}
+reqwest = {version = "0.11.17", default-features = false}
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 async-mutex = "1.4.0"
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["full"] }
+
+
+[features]
+default = ["default-tls"]
+default-tls = ["reqwest/default-tls"]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,19 @@ conn.transaction(|conn| async move {
 }).await?;
 ```
 
+### Features
+
+This crate uses [reqwest](https://docs.rs/reqwest/latest/reqwest/) for making http requests. By default, this crate will use the `default-tls` feature of `reqwest` which may not build in your environment (e.g. netlify serverless functions). You can override this by disabling the default features of this crate and enabling a different reqwest tls feature like so:
+
+```toml
+planetscale-driver = {version="0.3.2", default-features=false}
+reqwest= {version= "0.11.17", default-features=false, features=["rustls-tls"]}
+```
+
+> **Warning**
+> If you simply disable default features and do not enable a different tls feature, reqwest will panic at runtime.
+
+
 ### More examples in the [examples](examples) folder
 If you want to run them:
 ```bash

--- a/examples/tls-override/Cargo.toml
+++ b/examples/tls-override/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "planetscale-tls-override"
+version="0.3.2"
+edition = "2021"
+license = "MIT"
+
+[dependencies]
+planetscale-driver = {path= "../..", default-features=false}
+reqwest= {version= "0.11.17", default-features=false, features=["rustls-tls"]}
+tokio = { version = "1.28.0", features = ["full"] }
+anyhow = "1.0"

--- a/examples/tls-override/src/main.rs
+++ b/examples/tls-override/src/main.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+use planetscale_driver::{query, Database, PSConnection};
+use std::env::var;
+
+#[derive(Database, Debug)]
+pub struct TestD {
+    pub val: bool,
+}
+
+#[tokio::main]
+pub async fn main() -> Result<()> {
+    let mut conn = PSConnection::new(&var("PS_HOST")?, &var("PS_USER")?, &var("PS_PASS")?);
+
+    let res: TestD = query("SELECT true").fetch_one(&mut conn).await?;
+    println!("{:?}", res);
+
+    let res: bool = query("SELECT true").fetch_scalar(&mut conn).await?;
+    println!("{:?}", res);
+
+    return Ok(());
+}


### PR DESCRIPTION
Hi, thanks so much for making this crate - it really saved me. Unfortunately I was unable to use it in a netlify serverless function as I think the reqwest default tls provider needs openssl. I got around that by forking this repo and using the rustls-tls feature instead of the default. 

This pull request makes it possible for anyone to do that easily by using the following:

```toml
planetscale-driver = {version="0.3.2", default-features=false}
reqwest= {version= "0.11.17", default-features=false, features=["rustls-tls"]}
```

I've also added a section in the readme and an example.
Let me know whether you are happy with this idea and if you'd like me to make any changes.

Have a great day.